### PR TITLE
do not overwrite switchport trunk allowed vlan configs, add or delete configs

### DIFF
--- a/templates/dellos6_vlan.j2
+++ b/templates/dellos6_vlan.j2
@@ -56,10 +56,10 @@ exit
         {% if ports.port is defined and ports.port %}
           {% if ports.state is defined and ports.state=="absent" %}
 interface {{ ports.port }}
-no switchport trunk allowed vlan
+switchport trunk allowed vlan remove {{ vlan_id[1] }}
           {% else %}
 interface {{ ports.port }}
-switchport trunk allowed vlan {{ vlan_id[1] }}
+switchport trunk allowed vlan add {{ vlan_id[1] }}
           {% endif %}
         {% endif %}
 exit


### PR DESCRIPTION
By default, the template will overwrite the allowed vlans configs for each vlans.
Imagine you configure a switch with such vlans : 

vlan 2:
    tagged_members:
      - port: po1
vlan 3:
    untagged_members:
      - port: range Te1/0/6-24
    tagged_members:
      - port: po1

Then, with previous template, the generated config would have been something like this for po1 : 

interface po1
switchport trunk allowed vlan 2
exit
interface po1
switchport trunk allowed vlan 3
exit

The later switchport removes vlan2, and breaks your config and potentially your session if vlan2 is used for inband management.

https://github.com/Dell-Networking/ansible-role-dellos-vlan/issues/6  suggest using vlan keys such as "vlan 2,3" (how?), but what if you want to configure hybrid ports where you won't deploy all taggued vlans?

=> this PR should hopefully fix this.

Note : I have the impression this also affects dellos10 templates.

