### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos10_vlan.j2
+++ b/templates/dellos10_vlan.j2
@@ -22,7 +22,7 @@ dellos_vlan:
 
 #########################################}
 {% if dellos_vlan is defined and dellos_vlan %}
-{% for key,value in dellos_vlan.iteritems() %}
+{% for key,value in dellos_vlan.items() %}
   {% if key == "default_vlan_id" %}
     {% if value %}
 default vlan-id {{ value }}

--- a/templates/dellos9_vlan.j2
+++ b/templates/dellos9_vlan.j2
@@ -22,7 +22,7 @@ dellos_vlan:
         state: present
 #########################################}
 {% if dellos_vlan is defined and dellos_vlan %}
-{% for key,value in dellos_vlan.iteritems() %}
+{% for key,value in dellos_vlan.items() %}
   {% if key == "default_vlan" %}
     {% if value %}
 default-vlan disable


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs