### PR TITLE
Fix for VLAN description error

### DIFF
--- a/templates/dellos10_vlan.j2
+++ b/templates/dellos10_vlan.j2
@@ -37,7 +37,7 @@ no interface vlan{{ vlan_id[1] }}
 interface vlan{{ vlan_id[1] }}
     {% if vlan_vars.description is defined %}
       {% if vlan_vars.description %}
- description {{ vlan_vars.description }}
+ description "{{ vlan_vars.description }}"
       {% else %}
  no description
       {% endif %}


### PR DESCRIPTION
Double commiting changes from Local repo to Github
Problem statement:
When vlan description is given with spaces, illegal error is thrown.
Fix description:
Adding double quotes on vlan description.